### PR TITLE
fix: validate goavro codec building

### DIFF
--- a/cli/cmd/verifySchema.go
+++ b/cli/cmd/verifySchema.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"io/ioutil"
 
+	"github.com/linkedin/goavro/v2"
 	"github.com/ouzi-dev/avro-kedavro/pkg/kedavro"
 	"github.com/spf13/cobra"
 )
@@ -23,6 +24,12 @@ var verifySchemaCmd = &cobra.Command{
 		_, err = kedavro.NewParser(string(data), kedavro.WithStringToNumber(), kedavro.WithTimestampToMillis())
 		if err != nil {
 			// Error parsing schema
+			return err
+		}
+
+		_, err = goavro.NewCodec(string(data))
+		if err != nil {
+			// Error building a codec.
 			return err
 		}
 

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -3,6 +3,7 @@ module github.com/ouzi-dev/avro-kedavro/cli
 go 1.14
 
 require (
+	github.com/linkedin/goavro/v2 v2.9.7
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/ouzi-dev/avro-kedavro v0.4.0
 	github.com/spf13/cobra v1.0.0


### PR DESCRIPTION
There is one case (that we've found) where a avro schema can be
technically valid but we are unable to build a codec using goavro.

Specifically, we can specify a default value that does not match the
type declaration and verifySchema will not catch the issue.  It will be
a runtime error when we try to build the codec later.

The failure case is something like this:
```
{
  "name": "Wizard",
  "type": "record",
  "namespace": "com.avro.kedavro",
  "fields": [{
    "name": "name",
    "type": "string",
    "default": null
  }]
 }
```

The in the case above the format of the avro is correct but when it
comes time to coerce the default value (null) into the field the the
type "string" is not nullable.

This commit causes this to throw an error.